### PR TITLE
⬆️ Avalonia 11.2.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,16 +22,16 @@
     </PropertyGroup>
     <!-- Avalonia-->
     <PropertyGroup>
-        <Version_Avalonia>11.2.5</Version_Avalonia>
+        <Version_Avalonia>11.2.6</Version_Avalonia>
     </PropertyGroup>
     <PropertyGroup>
-        <Version_Avalonia_Xaml_Behaviors>11.2.0.9</Version_Avalonia_Xaml_Behaviors>
+        <Version_Avalonia_Xaml_Behaviors>11.2.0.14</Version_Avalonia_Xaml_Behaviors>
     </PropertyGroup>
     <PropertyGroup>
-        <Version_Avalonia_Edit>11.1.0</Version_Avalonia_Edit>
+        <Version_Avalonia_Edit>11.2.0</Version_Avalonia_Edit>
     </PropertyGroup>
     <PropertyGroup>
-        <Version_AvaloniaEdit_TextMate>11.1.0</Version_AvaloniaEdit_TextMate>
+        <Version_AvaloniaEdit_TextMate>11.2.0</Version_AvaloniaEdit_TextMate>
     </PropertyGroup>
     <PropertyGroup>
         <Version_Avalonia_Markdown>11.0.3-a1</Version_Avalonia_Markdown>
@@ -40,10 +40,10 @@
         <Version_Avalonia_CefNet>105.3.22248.142</Version_Avalonia_CefNet>
     </PropertyGroup>
     <PropertyGroup>
-        <Version_Avalonia_LibVLCSharp>3.9.0</Version_Avalonia_LibVLCSharp>
+        <Version_Avalonia_LibVLCSharp>3.9.2</Version_Avalonia_LibVLCSharp>
     </PropertyGroup>
     <PropertyGroup>
-        <Version_Avalonia_FluentUI>2.3.0</Version_Avalonia_FluentUI>
+        <Version_Avalonia_FluentUI>2.4.0-preview1</Version_Avalonia_FluentUI>
     </PropertyGroup>
     <PropertyGroup>
         <Version_Avalonia_LiveChartsCore_SkiaSharpView>2.0.0-rc5.4</Version_Avalonia_LiveChartsCore_SkiaSharpView>


### PR DESCRIPTION
Avalonia 11.2.6 had been released in 2025/3/29.
https://github.com/AvaloniaUI/Avalonia/releases/tag/11.2.6